### PR TITLE
Add --version option.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,22 +1,36 @@
 #!/usr/bin/env node
 
-var argv = require('optimist').argv;
+var argv = require('optimist')
+            .boolean('v')
+            .alias('v','version')
+            .alias('w', 'whitelist')
+            .argv;
+
 var fs = require('fs');
 
-var filename = argv._[0];
-var source = fs.readFileSync(filename).toString();
-
-var whitelist;
-if (argv.w) {
-  whitelist = JSON.parse(fs.readFileSync(argv.w).toString());
+if (argv.version) {
+  var version = require('../package').version;
+  process.stdout.write(version + '\n');
 } else {
-  whitelist = {};
+  var filename = argv._[0];
+  if (!filename){
+    process.stdout.write('You must supply the input file path.\n');
+    process.exit(1);
+  }
+
+  var source = fs.readFileSync(filename).toString();
+  var whitelist;
+  if (argv.w) {
+    whitelist = JSON.parse(fs.readFileSync(argv.w).toString());
+  } else {
+    whitelist = {};
+  }
+
+  var config = {
+    enabled: whitelist,
+    namespace: argv.n
+  };
+
+  var defeatureify = require(__dirname + "/../defeatureify.js");
+  process.stdout.write(defeatureify(source, config));
 }
-
-var config = {
-  enabled: whitelist,
-  namespace: argv.n
-};
-
-var defeatureify = require(__dirname + "/../defeatureify.js");
-process.stdout.write(defeatureify(source, config));


### PR DESCRIPTION
This will help us deal with https://github.com/emberjs/ember-dev/issues/54.  Basically, I am planning to get rid of any `which` calls and just call `defeatureify --version` or `phantomjs --version` to ensure that the executable is available.
