### PR TITLE
Proof of concept: Remove debug statements like `Ember.assert`

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,8 @@ var argv = require('optimist')
             .boolean('v')
             .alias('v','version')
             .alias('w', 'whitelist')
+            .boolean('s')
+            .alias('s', 'stripdebug')
             .argv;
 
 var fs = require('fs');
@@ -28,7 +30,8 @@ if (argv.version) {
 
   var config = {
     enabled: whitelist,
-    namespace: argv.n
+    namespace: argv.n,
+    stripdebug: argv.stripdebug
   };
 
   var defeatureify = require(__dirname + "/../defeatureify.js");

--- a/tests/fixture/strip_debug.in.js
+++ b/tests/fixture/strip_debug.in.js
@@ -1,0 +1,7 @@
+var o = Ember.Object.extend();
+Ember.assert("This should be removed");
+Ember.warn("This should be removed");
+Ember.debug("This should be removed");
+Ember.deprecate("This should be removed");
+Ember.Logger.info("This should be removed");
+Ember.run(o, o.destroy);

--- a/tests/fixture/strip_debug.out.js
+++ b/tests/fixture/strip_debug.out.js
@@ -1,0 +1,2 @@
+var o = Ember.Object.extend();
+Ember.run(o, o.destroy);

--- a/tests/test.js
+++ b/tests/test.js
@@ -52,3 +52,14 @@ exports.testFunctionDefinition = function(test) {
   // TODO
   test.done();
 };
+
+exports.testStripDebugStatements = function(test) {
+  var source = fs.readFileSync(__dirname + "/fixture/strip_debug.in.js").toString();
+  var expected = fs.readFileSync(__dirname + "/fixture/strip_debug.out.js").toString();
+  var res = defeatureify(source, {
+    stripdebug: true
+  });
+  test.expect(1);
+  test.equal(res, expected, "Ember debug messages are stripped");
+  test.done();
+}


### PR DESCRIPTION
This is a proof of concept to use the parsed syntax tree and remove all
debug statements like `Ember.[assert|deprecate|warn|debug]` or
`Ember.Logger.info`.

Currently those statements are required to be a oneliner and they are
removed by a simple string substitution (see http://git.io/i2wnpg).

By using something like this, it would be possible to even write
assertions like this:

``` javascript
Ember.assert("this is a complex error", function() {
  if (state === "isError" && !stateHandled) { return false; }
  if (state === "warning" || state === "info") { return false; }

  // return true, to indicate that the assertion was OK
  return true;
});
```

---

As stated above, this was just an experiment to see how easy it would to be to make this work. The assert statements in the Ember code can get quite [long](https://github.com/emberjs/ember.js/blob/3070328313b9c442d42b4ffb38790ee4683c2b41/packages/ember-views/lib/system/event_dispatcher.js#L104) and this would be a solution to solve this.

Any thoughts? Something worth putting more brain power into?
