### PR TITLE
Update version to 0.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
 ```
 
 * `-w`/`--whitelist` option is now `-c`/`--config`
-* Support stripping out debug statements:
+* Support stripping out debug statements (list specified in the config file with option `debugStatements`).
+  Can be enabled via either a config file option (`enableStripDebug`) or command line option (`--stripdebug`).
+
+  Example of enabling the stripping of debug statements in Ember:
 
 ```js
 //features.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defeatureify",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "",
   "main": "defeatureify.js",
   "bin": "./bin/cli.js",


### PR DESCRIPTION
I have submitted the first PR (https://github.com/emberjs/ember-dev/pull/118) to `ember-dev` enabling the use of `defeatureify` to strip debug statements.

I believe we are ready to publish 0.2.0.
