### PR TITLE
Throw an error not a string.

### DIFF
--- a/lib/source_modifier.js
+++ b/lib/source_modifier.js
@@ -31,7 +31,7 @@ SourceModifier.prototype = {
         index += curOp.diff;
         continue;
       }
-      throw 'Source location ' + index + ' has already been transformed!';
+      throw new Error('Source location ' + index + ' has already been transformed!');
     }
     return index;
   },


### PR DESCRIPTION
When using defeatureify with Broccoli, if a thrown error is a string you will
not receive additional stack track information (in the case of defeatureify
this means that you do not know the filename of the offender).

------

If possible, could you cut a new release once this is merged?