### PR TITLE
Handle Ember['default'].FEATURES.isEnabled.

### DIFF
--- a/defeatureify.js
+++ b/defeatureify.js
@@ -32,45 +32,67 @@ var defeatureify = function(source, config) {
     }
   };
 
+  var shouldProcessNode = function(node) {
+    // test object.property.property
+    if (node.test.callee.object &&
+        node.test.callee.object.object &&
+          node.test.callee.object.property) {
+      // test namespace.FEATURES.isEnabled()
+      if (node.test.callee.object.object.name === namespace &&
+          node.test.callee.object.property.name === "FEATURES" &&
+            node.test.callee.property.name === "isEnabled") {
+
+        return true;
+      }
+    }
+
+    // test object.object.{object,property} and object.property
+    if (node.test.callee.object &&
+          node.test.callee.object.object &&
+          node.test.callee.object.object.property &&
+          node.test.callee.object.object.object &&
+          node.test.callee.object.property) {
+      // test namespace['default'].FEATURES.isEnabled()
+      if (node.test.callee.object.object.object.name === namespace &&
+          node.test.callee.object.object.property.value === 'default' &&
+          node.test.callee.object.property.name === "FEATURES" &&
+            node.test.callee.property.name === "isEnabled") {
+
+        return true;
+      }
+    }
+  };
+
   var walk = function(node) {
     if (node.type === "IfStatement") {
       if (node.test.type === "CallExpression" && node.test.callee) {
-        // test object.property.property
-        if (node.test.callee.object &&
-            node.test.callee.object.object &&
-            node.test.callee.object.property) {
-          // test namespace.FEATURES.isEnabled()
-          if (node.test.callee.object.object.name === namespace &&
-              node.test.callee.object.property.name === "FEATURES" &&
-              node.test.callee.property.name === "isEnabled") {
+        if (shouldProcessNode(node)) {
+          var featureName = node.test.arguments[0].value;
 
-            var featureName = node.test.arguments[0].value;
+          if (enabled[featureName] === true) {
+            // remove if (x) {
+            sourceModifier.replace(node.range[0],
+                                   node.consequent.range[0], "");
 
-            if (enabled[featureName] === true) {
-              // remove if (x) {
-              sourceModifier.replace(node.range[0],
-                                     node.consequent.range[0], "");
+            // TODO: reindent
 
-              // TODO: reindent
+            // remove closing brace }
+            var body = node.consequent.body;
+            var lastStatement = body[body.length - 1];
+            sourceModifier.replace(node.consequent.range[1] - 1,
+                                   node.consequent.range[1] - 1, "");
 
-              // remove closing brace }
-              var body = node.consequent.body;
-              var lastStatement = body[body.length - 1];
-              sourceModifier.replace(node.consequent.range[1] - 1,
-                                     node.consequent.range[1] - 1, "");
-
-              // remove else clause if exists
-              if (node.alternate && node.alternate.type === "BlockStatement") {
-                sourceModifier.replace(node.consequent.range[1], node.alternate.range[1], "");
-              }
-            } else if (enabled[featureName] === false || enabled[featureName] === undefined) {
-              // remove if, leave else
-              if (!node.alternate) {
-                sourceModifier.replace(node.range[0], node.range[1], "");
-              } else {
-                sourceModifier.replace(node.range[0], node.alternate.range[0], "");
-                sourceModifier.replace(node.alternate.range[1]-1, node.alternate.range[1]-1, "");
-              }
+            // remove else clause if exists
+            if (node.alternate && node.alternate.type === "BlockStatement") {
+              sourceModifier.replace(node.consequent.range[1], node.alternate.range[1], "");
+            }
+          } else if (enabled[featureName] === false || enabled[featureName] === undefined) {
+            // remove if, leave else
+            if (!node.alternate) {
+              sourceModifier.replace(node.range[0], node.range[1], "");
+            } else {
+              sourceModifier.replace(node.range[0], node.alternate.range[0], "");
+              sourceModifier.replace(node.alternate.range[1]-1, node.alternate.range[1]-1, "");
             }
           }
         }

--- a/tests/fixture/namespace.default.in.js
+++ b/tests/fixture/namespace.default.in.js
@@ -1,0 +1,23 @@
+var foo;
+
+if (Ember['default'].FEATURES.isEnabled("experiment")) {
+  console.log("I'm some terrifying experimental stuff! Aaah!");
+  var baz;
+  // comments?
+  console.log("testing multi-lines");
+}
+
+if (Ember['default'].FEATURES.isEnabled("good-to-go")) {
+  console.log("Beta channel, whoo!");
+  var bar;
+  // comments?
+  console.log("testing multi-lines");
+}
+
+if (Ember['default'].FEATURES.isEnabled("ambivalent")) {
+  console.log("Meh, who cares");
+  var biff;
+  // comments?
+  console.log("testing multi-lines");
+}
+

--- a/tests/fixture/namespace.default.out.js
+++ b/tests/fixture/namespace.default.out.js
@@ -1,0 +1,17 @@
+var foo;
+
+
+
+  console.log("Beta channel, whoo!");
+  var bar;
+  // comments?
+  console.log("testing multi-lines");
+
+
+if (Ember['default'].FEATURES.isEnabled("ambivalent")) {
+  console.log("Meh, who cares");
+  var biff;
+  // comments?
+  console.log("testing multi-lines");
+}
+

--- a/tests/test.js
+++ b/tests/test.js
@@ -64,3 +64,14 @@ exports.testStripDebugStatements = function(test) {
   test.equal(res, expected, "Ember debug messages are stripped");
   test.done();
 };
+
+exports.testNamespaceDefault = function(test){
+  var source = fs.readFileSync(__dirname + "/fixture/namespace.default.in.js").toString();
+  var expected = fs.readFileSync(__dirname + "/fixture/namespace.default.out.js").toString();
+  var res = defeatureify(source, {
+    enabled: {"good-to-go": true, "ambivalent": null}
+  });
+  test.expect(1);
+  test.equal(res, expected, "Non-whitelisted feature was removed, whitelisted feature had conditional removed, and null feature was left flagged");
+  test.done();
+};


### PR DESCRIPTION
The update to Esperanto as Ember's module transpiler caused the resulting syntax to be slightly different than the es6-module-transpiler. Esperanto rewrites the calling location to use `dependency['default']` (to preserve bindings and handle cycles).

This PR allows both the old and new syntax to match and be processed.